### PR TITLE
Background for functional enrichment

### DIFF
--- a/restring/gears.py
+++ b/restring/gears.py
@@ -588,7 +588,7 @@ def write_all_summarized(
 
 def get_functional_enrichment(
     genes=None, species=None, caller_ID=session_ID,
-    allow_pubmed=0, verbose=True,
+    allow_pubmed=0, statistical_background=None, verbose=True,
     string_api_url = "https://string-db.org/api" # defaults to latest STRING release
 ):
 
@@ -630,12 +630,29 @@ def get_functional_enrichment(
     method = "enrichment"
     request_url = "/".join([string_api_url, output_format, method])
 
-    params = {
-    "identifiers": "%0d".join(genes),  # your proteins
-    "species": species,                # species NCBI identifier
-    "caller_identity": caller_ID,      # your app name
-    "allow_pubmed": 0,                 # this just seems to be ignored
-    }
+    if statistical_background is None:
+        say("Running the analysis against a statistical",
+            "background of the entire genome (default)."
+            )
+
+        params = {
+        "identifiers" : "%0d".join(genes), # your proteins
+        "species" : species,               # species NCBI identifier 
+        "caller_identity" : caller_ID,     # your app name
+        "allow_pubmed": 0,                 # this just seems to be ignored
+        }
+    else:
+        say("Running the analysis against a statistical",
+            "background of user-supplied terms."
+            )
+
+        params = {
+        "identifiers" : "%0d".join(genes), # your proteins
+        "species" : species,               # species NCBI identifier 
+        "caller_identity" : caller_ID,     # your app name
+        "allow_pubmed": 0,                 # this just seems to be ignored
+        "background_string_identifiers": "%0d".join(statistical_background)
+        }
 
     t0 = time()
     response = requests.post(request_url, data=params)

--- a/restring/gears.py
+++ b/restring/gears.py
@@ -602,9 +602,9 @@ def get_functional_enrichment(
 
     """
 
-    def say(stringlike, **kwargs):
+    def say(*args, **kwargs):
         if verbose:
-            print(stringlike, **kwargs)
+            print(*args, **kwargs)
 
     species_book = {
         "mouse": 10090,


### PR DESCRIPTION
This PR adds the `statistical_background` parameter to the `get_functional_enrichment()` function in `gears.py`. This allows users who use restring as a Python module to use `get_functional_enrichment()` with a background set to query STRING instead of having to use the STRING web interface manually.